### PR TITLE
We cannot always use an url when we use imagecreatefromgif()

### DIFF
--- a/gif-player.php
+++ b/gif-player.php
@@ -260,8 +260,9 @@ class WP_GIF_Player{
         //create a new file path by adding _still(.gif) to the current file path
         $new_still = preg_replace('/\.gif$/', '_still_tmp.jpeg', $img_url);
         $new_still_path = str_replace( home_url(), ABSPATH, $new_still); //hier kann auch ein Array übergeben werden
+        $img_path = str_replace(home_url(), ABSPATH, $img_url);
         //Extract the first frame of the gif as a jpeg file and save it to the media library.
-        imagejpeg(imagecreatefromgif($img_url), $new_still_path);
+        imagejpeg(imagecreatefromgif($img_path), $new_still_path);
 
         return $new_still_path; //return path to still first frame
     }


### PR DESCRIPTION
Change the call to imagecreatefromgif() with the absolute path of the GIF instead of the url